### PR TITLE
Use npm prefix on better-auth imports

### DIFF
--- a/packages/auth/auth.ts
+++ b/packages/auth/auth.ts
@@ -1,6 +1,6 @@
 import { betterAuth } from 'better-auth'
-import { magicLink, openAPI } from 'better-auth/plugins'
-import { drizzleAdapter } from 'better-auth/adapters/drizzle'
+import { magicLink, openAPI } from 'npm:better-auth/plugins'
+import { drizzleAdapter } from 'npm:better-auth/adapters/drizzle'
 
 import { db, schema } from '@workspace/db'
 


### PR DESCRIPTION
Minor change, but resolves a deno error where it thinks better-auth doesn't exist.

Side note: thanks for putting this together; it's a solid template for exploring deno monorepos.